### PR TITLE
Allow multiple galleries on a page

### DIFF
--- a/src/js/material-photo-gallery.js
+++ b/src/js/material-photo-gallery.js
@@ -171,7 +171,7 @@
   Gallery.prototype._layout = function() {
     var gallery = this
     var imgLoad = imagesLoaded(
-      document.querySelector('div[data-google-image-layout]')
+      gallery._element
     )
 
     imgLoad.on('progress', function(instance, image) {
@@ -181,6 +181,7 @@
 
     imgLoad.on('done', function(instance) {
       var g = new GoogleImageLayout().init({
+        element: gallery._element,
         after: function() {
           gallery.init()
         }
@@ -210,6 +211,7 @@
 
     window.onresize = debounce(function() {
       var g = new GoogleImageLayout().init({
+        element: gallery._element,
         after: function() {
           setTimeout(function() {
             gallery._handleResize()

--- a/src/js/vendor/google-image-layout.js
+++ b/src/js/vendor/google-image-layout.js
@@ -91,7 +91,7 @@
 
   GoogleImageLayout.init = function(opts) {
     opts = opts || {}
-    var nodes = document.querySelectorAll('div[data-google-image-layout]')
+    var nodes = (opts.element || document).querySelectorAll('div[data-google-image-layout]')
     var length = nodes.length
     var elem
 


### PR DESCRIPTION
### Problem

When I tried to add this gallery to my blog, it worked fine, but only for the first gallery on the page.

Adding multiple image sets, the 2nd+ galleries did not have the layout rules applied properly. The images appeared, but not according to the material layout scheme, and the js console showed errors about `this._fullImgs` being undefined.

I was calling `new MaterialPhotoGallery(myelem)` for each gallery. It looked like the document-level query selectors meant that the first call was applying some changes across all galleries/images, and any later galleries got stuck half-initialized.

### Fix 

Scope all the query selectors to the element containing the single gallery. Anyone using this plugin according to the readme/example shouldn't have to change anything.

* Change argument to imagesLoaded() so it only searches under the gallery element
* Add a new element option to the options object passed to GoogleImageLayout.init()
* Change GoogleImageLayout.init() so it searches under element if set, or from the document root otherwise

### Example after fix

https://bitswamp.com/2018/10/26/logitech-joystick-usb-adapter/

(uses the unminified js bundle)

Thanks for reviewing 🙂 